### PR TITLE
add error mv execution

### DIFF
--- a/scripts/lift.py
+++ b/scripts/lift.py
@@ -103,6 +103,7 @@ def lift(args):
         mv_cmd = f"mv -f variants_lifted {args.out}"
         subprocess.run(shlex.split(mv_cmd))
         mv_cmd = f"mv -f errors {args.out}"
+        subprocess.run(shlex.split(mv_cmd))
 
 if __name__=='__main__':
 


### PR DESCRIPTION
The command to move 'errors' file in lift.py was never executed. Added it so the file is where you'd expect.