### PR TITLE
add list chunking script

### DIFF
--- a/chunk_list/README.md
+++ b/chunk_list/README.md
@@ -1,0 +1,26 @@
+# Divide a list into many N-sized chunks
+
+This script divides a file with many lines into many files with N or less lines.  The line order or line contents (including line endings) is not changed.
+
+For example, to divide a phenotype list into files with 500 lines:
+
+```
+python3 chunk_list.py FILE --n 500
+ls -1
+> FILE_1_500
+> FILE_501_1000
+> FILE_1001_1501
+#etc etc
+```
+
+## Usage
+```
+usage: Chunk a file into chunks of size n [-h] [--n-lines N_LINES] file
+
+positional arguments:
+  file
+
+optional arguments:
+  -h, --help         show this help message and exit
+  --n-lines N_LINES  lines per chunk
+```

--- a/chunk_list/scripts/chunk_list.py
+++ b/chunk_list/scripts/chunk_list.py
@@ -1,0 +1,38 @@
+"""Chunk a file into multiple files
+"""
+
+import argparse as ap
+import itertools
+
+def grouper_it(n, iterable):
+    it = iter(iterable)
+    while True:
+        chunk_it = itertools.islice(it, n)
+        try:
+            first_el = next(chunk_it)
+        except StopIteration:
+            return
+        yield itertools.chain((first_el,), chunk_it)
+
+def chunk_file(fname, n_lines):
+    """Chunk a file into multiple lines
+    Save those files as filename_start_end
+    """
+    with open(fname,"r") as f:
+        for idx,chunk in enumerate(grouper_it(n_lines,f)):
+            ch = list(chunk)
+            start = n_lines*idx +1
+            end = min(n_lines*(idx+1),(n_lines*idx + len(ch)))
+            print(start,end)
+            with open(f"{fname}_{start}_{end}","w") as writer:
+                writer.writelines(ch)
+
+
+if __name__=="__main__":
+    parser = ap.ArgumentParser("Chunk a file into chunks of size n")
+    parser.add_argument("file")
+    parser.add_argument("--n-lines",type=int,help="lines per chunk")
+
+    args = parser.parse_args()
+
+    chunk_file(args.file, args.n_lines)


### PR DESCRIPTION
I've recently been chunking phenotype lists a lot when running analyses and thought that maybe someone else also does that sometimes. Here's a helper script for doing that.

Currently lists/files with headers are NOT supported, though that would be an easy fix if needed.