### PR TITLE
add vcf to bgen while filtering wdl used in chip-analysis to commons

### DIFF
--- a/vcf_bgen_filter/README.md
+++ b/vcf_bgen_filter/README.md
@@ -1,0 +1,3 @@
+# Convert vcf to bgen, filtering variants with allele frequency
+
+Used in chip-analysis.

--- a/vcf_bgen_filter/wdl/filter_vcf_to_bgen_af.json
+++ b/vcf_bgen_filter/wdl/filter_vcf_to_bgen_af.json
@@ -1,0 +1,5 @@
+{
+    "filter_vcf_to_bgen.files_to_conv": "gs://r7_data/chip/R7_chip_vcf.txt",
+    "filter_vcf_to_bgen.af": 0.1,
+    "filter_vcf_to_bgen.combine.outfile": "R7_chip_af_0.1.bgen"
+}

--- a/vcf_bgen_filter/wdl/filter_vcf_to_bgen_af.wdl
+++ b/vcf_bgen_filter/wdl/filter_vcf_to_bgen_af.wdl
@@ -1,0 +1,81 @@
+task filter {
+
+    File vcf
+    Float af
+    Float af_ = 1-af
+    String genofield
+    String ofiletype
+    Int precision
+    Float input_rounding_error
+
+    command <<<
+
+        bcftools filter -i'AF<${af} || AF>${af_}' ${vcf} | \
+        qctool -g - -filetype vcf -vcf-genotype-field ${genofield} -og ${basename(vcf)}.bgen -bgen-compression zlib -ofiletype ${ofiletype} -bgen-bits ${precision} -bgen-permitted-input-rounding-error ${input_rounding_error}
+
+    >>>
+
+    runtime {
+        docker: "gcr.io/finngen-refinery-dev/bioinformatics:0.6"
+        cpu: 2
+        disks: "local-disk 200 HDD"
+        zones: "europe-west1-b europe-west1-c europe-west1-d"
+        preemptible: 2
+    }
+
+    output {
+        File outbgen = "${basename(vcf)}.bgen"
+    }
+}
+
+task combine {
+
+    Array[File] bgenfiles
+    String outfile
+
+    command <<<
+        cat-bgen -g ${sep=" " bgenfiles} -og ${outfile}
+        bgenix -g ${outfile} -index
+    >>>
+
+    runtime {
+        docker: "gcr.io/finngen-refinery-dev/bioinformatics:0.6"
+        cpu: 1
+        disks: "local-disk 200 HDD"
+        zones: "europe-west1-b europe-west1-c europe-west1-d"
+        preemptible: 2
+    }
+
+    output {
+        File out = outfile
+        File out_index = outfile + ".bgi"
+    }
+}
+
+workflow filter_vcf_to_bgen {
+
+    File files_to_conv
+    Float af
+    String genofield="GT"
+    String ofiletype="bgen_v1.2"
+    Int precision=8
+    Float input_rounding_error=0.005
+
+    Array[String] files = read_lines(files_to_conv)
+
+    scatter( file in files) {
+
+        call filter {
+            input: vcf=file,
+            af=af,
+            genofield=genofield,
+            ofiletype=ofiletype,
+            precision=precision,
+            input_rounding_error=input_rounding_error
+        }
+    }
+
+    call combine {
+        input: bgenfiles=filter.outbgen
+    }
+}


### PR DESCRIPTION
Add the workflow converting vcfs to a bgen, filtering variants with maf > VALUE out. Used in chip-analysis to filter out high-frequency variants because typically no need to analyze them from the chip data.

Changes to script:
- Add more zones in west-1 (b,c,d)