### PR TITLE
add cromwell utility scripts

### DIFF
--- a/cromwell_utils/README.md
+++ b/cromwell_utils/README.md
@@ -1,0 +1,38 @@
+# Utilities for metadata
+
+This folder contains utilities for working with cromwell-produced files (metadata, outputs). The following scripts are provided:
+- `outputs_to_lists.py`, which extracts outputs to their own lists from an outputs.json file. Outputs of the same type are put in same files, and nested arrays are flattened. Those can be used in copying files, for example: `cat filelist|gsutil -m cp -I gs://output_bucket/`
+- `extract_timing.py`, which extracts timing data from a list of workflows' metadata files and saves it as a TSV.
+- `get_subworkflowids.py`, which extracts subworkflow IDs from a metadata json. This is useful for e.g. bulk downloading all subworkflow metadata
+
+## Requirements
+
+These scripts require python 3.6+
+
+## Usage
+
+Get a list of subworkflowids from a metadata file & download the associated metadata:
+
+```bash
+PROXY_PORT=5000
+python3 get_subworkflowids.py metadata.json
+#subworkflowids saved to subworkflowid named files, such as regenie.step2
+#download metadata, 4 parallel processes
+mkdir subworkflows
+cat regenie.step2|xargs -I %  -P 4 bash -c 'curl --sS -X POST http://localhost:80/api/workflows/v1/{}/metadata -H "accept: application/json" -H "Content-Type: multipart/form-data" --socks5 localhost:PROXY_PORT -o subworkflows/{}.json'
+```
+
+extract task timing from the subworkflows:
+```bash
+python3 extract_timing.py subworkflows/*.json --tasknames "regenie_step2.step2" --inputfields "input1" "input2" "input3"  --out extracted_data_step2.tsv
+```
+this timing data can then be drilled down using e.g. R to see pre-emption rates, calculate approximate cost etc.
+
+Download outputs from a workflow:
+```bash
+python3 outputs_to_lists.py outputs.json --out-folder output_lists
+ls output_lists
+>workflow.output1
+>workflow.output2
+>workflow.output3
+```

--- a/cromwell_utils/scripts/extract_timing.py
+++ b/cromwell_utils/scripts/extract_timing.py
@@ -1,0 +1,128 @@
+import json
+import argparse
+from typing import NamedTuple,List, Dict
+
+class TimingData(NamedTuple):
+    job: str
+    status: str
+    attempt: int
+    start: str
+    end: str
+    n_phenos: int
+    chrom: str
+    cluster: str
+    n_cpus: int
+
+class Task(NamedTuple):
+    status: str
+    preemptible: bool
+    attempt: int
+    start: str
+    end: str
+    n_cpus: int
+    mem: int
+    data: Dict[str,str]
+
+class WorkFlow(NamedTuple):
+    id: str
+    tasks: List[Task]
+
+
+def extract_data(jsondata, tasklist:List[str], input_fields:List[str])->WorkFlow:
+    """
+    Extract tasks from a workflow.
+    Args:
+        jsondata (Any): the json data we parse
+        tasklist (List[str]): List of tasks to extract
+        input_fields (List[str]): List of input fields to extract from the tasks (e.g. chromosome, input file)
+    """
+    taskname = jsondata["id"]
+    out_tasks = []
+    for jobname,joblist in jsondata["calls"].items():
+        if jobname in tasklist:
+            for task in joblist:
+                #filter out callcached results
+                if "backendStatus" not in task.keys():
+                    continue
+                execstatus = task["executionStatus"]
+                backendstatus = task["backendStatus"]
+                if execstatus == "Done":
+                    #load userAction
+                    status = "Success"
+                    actions = [a for a in task["executionEvents"] if "description" in a.keys()]
+                    action = [a for a in actions if a["description"]=="UserAction"][0]
+                elif execstatus == "RetryableFailure" and backendstatus == "Preempted":
+                    status = "Preempted"
+                    action = [a for a in task["executionEvents"] if a["description"]=="RunningJob"][0]
+                elif execstatus == "Failed":
+                    status = "Failed"
+                    action = [a for a in task["executionEvents"] if a["description"]=="RunningJob"][0]
+                else:
+                    #couldn't identify the task type, might be callcaching, 
+                    continue
+                #get runtimeattributes
+                start = action["startTime"]
+                end = action["endTime"]
+                preemptible = task["preemptible"]
+                attempt = int(task["attempt"])
+                #note: currently google adds at least 2 cpus for machines, change this if that becomes
+                n_cpus = max(int(task["runtimeAttributes"]["cpu"]),2)
+                mem = int(task["runtimeAttributes"]["memory"].split(" ")[0])
+                #get input fields
+                inputs = {}
+                for field in input_fields:
+                    try:
+                        inputs[field] = task["inputs"][field]
+                    except:
+                        raise Exception(f"Field {field} not in inputs of task {jobname}")
+                out_tasks.append(
+                    Task(
+                        status,
+                        preemptible,
+                        attempt,
+                        start,
+                        end,
+                        n_cpus,
+                        mem,
+                        inputs
+                    )
+                )
+    return WorkFlow(taskname,out_tasks)
+
+def main(files,tasklist, input_fields, outfilename):
+    # read files
+    workflows = []
+    for fname in files:
+        with open(fname,"r") as f:
+            d=json.load(f)
+            workflows.append( extract_data(d,tasklist, input_fields) )
+    #write output
+    headercols = ["id","status","preemtible","attempt","start","end","n_cpus","mem"]+input_fields
+    header = "\t".join( map(str,headercols) )+"\n"
+    
+    with open(outfilename,"w") as outfile:
+        outfile.write(header)
+        for workflow in workflows:
+            for task in workflow.tasks:
+                columns = [
+                    workflow.id,
+                    task.status,
+                    task.preemptible,
+                    task.attempt,
+                    task.start,
+                    task.end,
+                    task.n_cpus,
+                    task.mem,
+                ]
+                columns = columns + [task.data[i] for i in input_fields]
+                line = "\t".join(map(str,columns))+"\n"
+                outfile.write(line)
+
+if __name__ == "__main__":
+    parser=argparse.ArgumentParser("Extract timing data (including whether the task was pre-empted, and which attempt it was) from metadata file(s)")
+    parser.add_argument("--out",required=True)
+    parser.add_argument("files",nargs="+")
+    parser.add_argument("--tasknames",nargs="+",help="list of task names to extract from workflow metadata")
+    parser.add_argument("--inputfields",nargs="*",help="Extract input fields from ")
+    args=parser.parse_args()
+    main(args.files,args.tasknames, args.inputfields, args.out)

--- a/cromwell_utils/scripts/get_subworkflowids.py
+++ b/cromwell_utils/scripts/get_subworkflowids.py
@@ -1,0 +1,19 @@
+import argparse
+import json
+from collections import defaultdict
+
+if __name__=="__main__":
+    parser=argparse.ArgumentParser()
+    parser.add_argument("files",nargs = "+")
+    args=parser.parse_args()
+    calls = defaultdict(list)
+    for fname in args.files:
+        with open(fname) as f:
+            data=json.load(f)
+            for key,value in data["calls"].items():
+                for call in value:
+                    calls[key].append(call['subWorkflowId'])
+    for key, values in calls.items():
+        with open(key,"w") as outfile:
+            for v in values:
+                outfile.write(f"{v}\n")

--- a/cromwell_utils/scripts/outputs_to_lists.py
+++ b/cromwell_utils/scripts/outputs_to_lists.py
@@ -1,0 +1,55 @@
+import json
+import argparse
+import os
+from typing import List
+
+def flatten(A):
+    rt = []
+    for i in A:
+        if isinstance(i,list):
+            rt.extend(flatten(i))
+        else:
+            rt.append(i)
+    return rt
+
+def main(files:List[str],out_folder:str):
+    data = {}
+    for f_path in files:
+        with open(f_path,"r") as f:
+            json_data=json.load(f)
+            outs = json_data["outputs"]
+            data[f_path]=outs
+    #data layout: data contains dictionaries with values being the outputs.
+    #If we want to join them, we need to 1) get keys, 2) 
+    out_types = []
+    for v in data.values():
+        out_types.extend(list(v.keys()))
+    all_keys = sorted(set(out_types))
+    outputs = {}
+    for key in all_keys:
+        outputs[key]=[]
+    for key in all_keys:
+        for batchdata in data.values():
+            if key in batchdata:
+                tmp=flatten(batchdata[key])
+                outputs[key].extend(tmp)
+    #create folder if necessary
+    if not os.path.isdir(out_folder):
+        os.makedirs(out_folder)
+    #write outputs
+    for key,out in outputs.items():
+        #out might still need to be unrolled
+        tmp = flatten(out)
+        fname = os.path.join(out_folder,key)
+        with open(fname, "w") as f:
+            for line in tmp:
+                f.write(f"{line}\n")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser("create output lists from outputs jsons")
+    ap.add_argument("files",metavar="FILES",nargs="+")
+    ap.add_argument("--out-folder",type=str, required=True)
+    args = ap.parse_args()
+
+    main(args.files, args.out_folder)


### PR DESCRIPTION
This PR adds some utility scripts I've been using lately for working with cromwell - Mainly after getting metadata and outputs and processing them into e.g. timing data or into separate output lists.

Some of this might overlap with what cromwellInteract does - In that case it might be that I should use that instead, so feel free to point that out. I didn't however see if there's functionality for listing and flattening outputs from an output json, or for extracting task-specific data from a one or multiple metadata jsons, so created this.