### PR TITLE
replace column choosing with awk script that aborts on miss

### DIFF
--- a/variant_annotation/wdl/scrape_annot_v4.wdl
+++ b/variant_annotation/wdl/scrape_annot_v4.wdl
@@ -28,6 +28,7 @@ task join_annot {
 		exists=value in h
 		if(!exists)
 		{
+			system("echo ERROR header did not contain column "value"  >&2")
 			exit 1
 		}
 		exit 0


### PR DESCRIPTION
The annotation scraping had the following bug: The vep column indices were not properly identified.
I changed the implementation to an awk script, that will cycle through the header's columns, and either print the column index or exit with status 1.

Instead of `set -euxo pipefail`, I used `set -eux`, since head -1 sometimes triggers pipefail.