### PR TITLE
fix dbsnp normalization

### DIFF
--- a/dbsnp_vcf_process/wdl/map_vcf.wdl
+++ b/dbsnp_vcf_process/wdl/map_vcf.wdl
@@ -23,7 +23,7 @@ task vcf_task{
         cat ${chrom_map}|sed "s/23$/X/g;s/24$/Y/g;s/25$/M/g;s/\t/\tchr/g" > fasta_compliant_chrom_map
         paste <(cut -f 2 fasta_compliant_chrom_map) <(cut -f 2 ${chrom_map}) > chrtonum
         #rename & resctrict chromosomes
-        bcftools view   vcf_file.vcf.gz -m 2 -M 2 -r ${sep=',' old_chr_names} -Ou| \
+        bcftools view vcf_file.vcf.gz -r ${sep=',' old_chr_names} -Ou| \
         bcftools annotate --rename-chr fasta_compliant_chrom_map -Ou | \
         bcftools norm -f ${fasta} -c wx  -Ou| \
         bcftools annotate --rename-chr chrtonum -Ov|bgzip -@4 > output.vcf.gz 


### PR DESCRIPTION
Due to not understanding bcftools, the options in converting dbsnp file were wrong, and some alleles were dropped. This PR fixes the options, and the dbsnp file is now normalized correctly.