### PR TITLE
Variant annotation with gnomad v4.1

### DIFF
--- a/gnomad_parse/parse_gnomad_vcf.gnomad4.1.exomes.json
+++ b/gnomad_parse/parse_gnomad_vcf.gnomad4.1.exomes.json
@@ -1,0 +1,30 @@
+{
+  "parse_gnomad_vcf.vcfs":
+  [
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr1.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr2.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr3.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr4.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr5.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr6.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr7.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr8.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr9.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr10.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr11.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr12.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr13.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr14.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr15.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr16.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr17.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr18.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr19.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr20.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr21.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr22.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrX.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrY.vcf.bgz"
+  ],
+  "parse_gnomad_vcf.docker": "eu.gcr.io/finngen-refinery-dev/bioinformatics:0.8.2"
+}

--- a/gnomad_parse/parse_gnomad_vcf.gnomad4.1.genomes.json
+++ b/gnomad_parse/parse_gnomad_vcf.gnomad4.1.genomes.json
@@ -1,0 +1,30 @@
+{
+  "parse_gnomad_vcf.vcfs":
+  [
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr1.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr2.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr3.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr4.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr5.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr6.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr7.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr8.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr9.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr10.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr11.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr12.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr13.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr14.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr15.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr16.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr17.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr18.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr19.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr20.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr21.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr22.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrX.vcf.bgz",
+    "gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrY.vcf.bgz"
+  ],
+  "parse_gnomad_vcf.docker": "eu.gcr.io/finngen-refinery-dev/bioinformatics:0.8.2"
+}

--- a/gnomad_parse/parse_gnomad_vcf.wdl
+++ b/gnomad_parse/parse_gnomad_vcf.wdl
@@ -1,0 +1,128 @@
+version 1.0
+
+workflow parse_gnomad_vcf {
+
+    input {
+        Array[File] vcfs
+        String docker
+    }
+
+    scatter(vcf in vcfs) {
+        call parse {
+            input:
+                vcf = vcf,
+                docker = docker
+        }
+    }
+
+    call concat {
+        input:
+            parsed = parse.parsed,
+            docker = docker
+    }
+
+    output {
+        Array[File] parsed = parse.parsed
+        File merged = concat.merged
+    }
+}
+
+task parse {
+
+    input {
+        File vcf
+        String docker
+    }
+
+    String base = sub(sub(basename(vcf, ".bgz"), ".gz$", ""), ".vcf$", "")
+    Int local_disk = ceil(size(vcf, "G") * 2 + 2)
+
+    command <<<
+        
+        set -euxo pipefail
+
+        bcftools query -H -f '%CHROM\t%POS\t%REF\t%ALT\t%ID\t%INFO/AF_fin\t%INFO/AF_nfe\t%INFO/AF_afr\t%INFO/AF_amr\t%INFO/AF_asj\t%INFO/AF_eas\t%INFO/AF_mid\t%INFO/AF_sas\t%INFO/AC_fin\t%INFO/AC_nfe\t%INFO/AC_afr\t%INFO/AC_amr\t%INFO/AC_asj\t%INFO/AC_eas\t%INFO/AC_mid\t%INFO/AC_sas\t%INFO/AN_fin\t%INFO/AN_nfe\t%INFO/AN_afr\t%INFO/AN_amr\t%INFO/AN_asj\t%INFO/AN_eas\t%INFO/AN_mid\t%INFO/AN_sas\n' ~{vcf} | \
+        awk '
+        BEGIN {
+            FS=OFS="\t"
+        } NR == 1 {
+            for(i=1; i<=NF; i++) {
+                sub(/\[.*\]/, "", $i);
+                sub(/ /, "", $i)
+                h[$i] = i
+            }
+            print $0, "enrichment_nfe"
+        } NR > 1 {
+            for(i=1; i<=NF; i++) {
+                if ($i == ".") {
+                    $i = "NA"
+                }
+            }
+            enr = "NA"
+            if ($h["AF_nfe"] > 0 && $h["AF_fin"] != "NA" && $h["AF_nfe"] != "NA") {
+                enr = $h["AF_fin"] / $h["AF_nfe"]
+            }
+            print $0, enr
+        }' | bgzip > ~{base}.tsv.gz
+
+        tabix -s 1 -b 2 -e 2 ~{base}.tsv.gz
+
+    >>>
+
+    output {
+        File parsed = "~{base}.tsv.gz"
+        File parsed_tbi = "~{base}.tsv.gz.tbi"
+    }
+
+    runtime {
+        docker: "~{docker}"
+        cpu: "4"
+        memory: "32 GB"
+        disks: "local-disk ~{local_disk} HDD"
+        zones: "europe-west1-b europe-west1-c europe-west1-d"
+        preemptible: 1
+        noAddress: true
+    }
+}
+
+task concat {
+
+    input {
+        Array[File] parsed
+        String docker
+    }
+
+    String base = sub(basename(parsed[0], ".tsv.gz"), ".chr[0-9]*$", "")
+    Int local_disk = ceil(size(parsed, "G") * 2 + 2)
+
+    command <<<
+        
+        set -euxo pipefail
+
+        cat <(zcat -f ~{parsed[0]} | head -1) \
+            <(for file in ~{sep=" " parsed}; do
+                zcat -f $file | tail -n +2;
+            done) \
+        | bgzip > ~{base}.merged.tsv.gz
+
+        echo "`date` tabixing"
+        tabix -s 1 -b 2 -e 2 ~{base}.merged.tsv.gz
+        echo "`date` done"
+
+    >>>
+
+    output {
+        File merged = "~{base}.merged.tsv.gz"
+        File merged_tbi = "~{base}.merged.tsv.gz.tbi"
+    }
+
+    runtime {
+        docker: "~{docker}"
+        cpu: "2"
+        memory: "8 GB"
+        disks: "local-disk ~{local_disk} HDD"
+        zones: "europe-west1-b europe-west1-c europe-west1-d"
+        preemptible: 1
+        noAddress: true
+    }
+}

--- a/variant_annotation/wdl/scrape_annot_v4.wdl
+++ b/variant_annotation/wdl/scrape_annot_v4.wdl
@@ -18,6 +18,7 @@ task join_annot {
 
 	command <<<
 		set -eux
+
 		#save headercheck to file
 		cat > headercheck.awk <<'CODE'
 		{
@@ -35,35 +36,38 @@ task join_annot {
 		}
 		CODE
 
+        #helper function
+        body ()
+        {
+            IFS= read -r header;
+            printf '%s\n' "$header";
+            "$@"
+        }
+
+        awk 'BEGIN{FS=OFS="\t"} NR==1 { for(i=1;i<=NF;i++) sub(/_chr1$/, "", $i); print } FNR>1' ${sep=" " files} | bgzip > annotated_variants.gz.tmp
+
 		#if there are no external annots, then just simply concat files
-		if [[ -z "${external_annot}" ]]; then
-			awk 'BEGIN{FS=OFS="\t"} NR==1 { for(i=1;i<=NF;i++) sub(/_chr1$/, "", $i); print } FNR>1' ${sep=" " files} | bgzip > annotated_variants.gz
-		else
-			#else sort VEP and annotation files in similar order, then join
-			
+		if [[ ! -z "${external_annot}" ]]; then
 			#headercheck: check that the column is in header, else abort with error 1
-			vep_varcol=$(zcat ${external_annot} |head -n1|awk -v value="variant" -F "\t" -f headercheck.awk)
-			vep_conscol=$(zcat ${external_annot}|head -n1|awk -v value="most_severe" -F "\t" -f headercheck.awk )
-			vep_genecol=$(zcat ${external_annot}|head -n1|awk -v value="gene_most_severe" -F "\t" -f headercheck.awk)
-			cat <(zcat ${external_annot}|head -n1|cut -f $vep_varcol,$vep_conscol,$vep_genecol) <(zcat ${external_annot}|cut -f $vep_varcol,$vep_conscol,$vep_genecol|sort -k 1b,1)|bgzip > sorted_vep.gz
+			vep_varcol=$(zcat ${external_annot} | head -n1 | awk -v value="variant" -F "\t" -f headercheck.awk)
+			vep_conscol=$(zcat ${external_annot}| head -n1 | awk -v value="most_severe" -F "\t" -f headercheck.awk )
+			vep_genecol=$(zcat ${external_annot}| head -n1 | awk -v value="gene_most_severe" -F "\t" -f headercheck.awk)
+
+			zcat ${external_annot} | cut -f $vep_varcol,$vep_conscol,$vep_genecol | body sort -V -k 1,1 -T ./ | bgzip > sorted_vep.gz
 			#sort annotation
-			awk 'BEGIN{FS=OFS="\t"} NR==1 { for(i=1;i<=NF;i++) sub(/_chr1$/, "", $i); print } FNR>1' ${sep=" " files} | bgzip > annotated_variants_1.gz
-			cat <(zcat annotated_variants_1.gz|head -n1)  <(zcat annotated_variants_1.gz|tail -n+2|sort  -k 1b,1 -T ./) |bgzip  > sorted_annotated.gz
+			zcat annotated_variants.gz.tmp | body sort -V -k 1,1 -T ./ | bgzip  > sorted_annotated.gz
 			#join
-			join -t $'\t' -1 1 -2 1 -e "NA" --header -a 1 <(zcat sorted_annotated.gz) <(zcat sorted_vep.gz)|sort -V -k1,1 -T ./ |bgzip  > annotated_variants.gz
+			join --nocheck-order -t $'\t' -1 1 -2 1 -e "NA" --header -a 1 <(zcat sorted_annotated.gz) <(zcat sorted_vep.gz) | bgzip > annotated_variants.gz
 		fi
 
 		tabix -b 3 -e 3 -s 2 annotated_variants.gz
 
 	>>>
 
-
-
 	output {
 		File out="annotated_variants.gz"
 		File index="annotated_variants.gz.tbi"
 	}
-
 
 }
 

--- a/variant_annotation/wdl/scrape_annot_v4.wdl
+++ b/variant_annotation/wdl/scrape_annot_v4.wdl
@@ -367,40 +367,44 @@ task add_gnomad {
 
                 #genome
                 while gen_ref.has_lines and gen_ref.chrom < chrom or ( gen_ref.chrom == chrom and gen_ref.pos < pos):
-                    gen_ref.line = gen_ref.fp.readline().rstrip('\r\n').split('\t')
-                    try:
+                    line_temp = gen_ref.fp.readline().rstrip('\r\n')
+                    if line_temp == "":
+                        gen_ref.has_lines = False
+                    else:
+                        gen_ref.line = line_temp.split('\t')
                         gen_ref.pos = int(gen_ref.line[gen_ref.h_idx["POS"]])
                         gen_ref.chrom = format_chrom(gen_ref.line[gen_ref.h_idx["#CHROM"]])
-                    except ValueError:
-                        gen_ref.has_lines = False
                     
                 #exome
                 while exo_ref.has_lines and exo_ref.chrom < chrom or (exo_ref.chrom == chrom and exo_ref.pos < pos):
-                    exo_ref.line = exo_ref.fp.readline().rstrip('\r\n').split('\t')
-                    try:
+                    line_temp = exo_ref.fp.readline().rstrip('\r\n')
+                    if line_temp == "":
+                        exo_ref.has_lines = False
+                    else:
+                        exo_ref.line = line_temp.split('\t')
                         exo_ref.pos = int(exo_ref.line[exo_ref.h_idx["POS"]])
                         exo_ref.chrom = format_chrom(exo_ref.line[exo_ref.h_idx["#CHROM"]])
-                    except ValueError:
-                        exo_ref.has_lines = False
                 
                 #drain all lines with same chrom & pos to gen_vars
                 while gen_ref.has_lines and ( gen_ref.chrom == chrom and gen_ref.pos == pos ):
                     gen_vars.append(gen_ref.line)
-                    gen_ref.line = gen_ref.fp.readline().rstrip("\r\n").split('\t')
-                    try:
-                        gen_ref.chrom = format_chrom(gen_ref.line[gen_ref.h_idx['#CHROM']])
-                        gen_ref.pos = int(gen_ref.line[gen_ref.h_idx['POS']])
-                    except ValueError:
+                    line_temp = gen_ref.fp.readline().rstrip('\r\n')
+                    if line_temp == "":
                         gen_ref.has_lines = False
+                    else:
+                        gen_ref.line = line_temp.split('\t')
+                        gen_ref.pos = int(gen_ref.line[gen_ref.h_idx["POS"]])
+                        gen_ref.chrom = format_chrom(gen_ref.line[gen_ref.h_idx["#CHROM"]])
                 
                 while exo_ref.has_lines and ( exo_ref.chrom == chrom and exo_ref.pos == pos ):
                     exo_vars.append(exo_ref.line)
-                    exo_ref.line = exo_ref.fp.readline().rstrip("\r\n").split('\t')
-                    try:
-                        exo_ref.chrom = format_chrom(exo_ref.line[exo_ref.h_idx['#CHROM']])
-                        exo_ref.pos = int(exo_ref.line[exo_ref.h_idx['POS']])
-                    except ValueError:
+                    line_temp = exo_ref.fp.readline().rstrip('\r\n')
+                    if line_temp == "":
                         exo_ref.has_lines = False
+                    else:
+                        exo_ref.line = line_temp.split('\t')
+                        exo_ref.pos = int(exo_ref.line[exo_ref.h_idx["POS"]])
+                        exo_ref.chrom = format_chrom(exo_ref.line[exo_ref.h_idx["#CHROM"]])
 
                 #if the chrom and pos are the same, we try to match the variants. Else, we reset the respective {gen,exo}_vars
                 gen_values = ["NA"]*len(genome_cols)

--- a/variant_annotation/wdl/scrape_annot_v4.wdl
+++ b/variant_annotation/wdl/scrape_annot_v4.wdl
@@ -45,12 +45,12 @@ task join_annot {
 			vep_varcol=$(zcat ${external_annot} |head -n1|awk -v value="variant" -F "\t" -f headercheck.awk)
 			vep_conscol=$(zcat ${external_annot}|head -n1|awk -v value="most_severe" -F "\t" -f headercheck.awk )
 			vep_genecol=$(zcat ${external_annot}|head -n1|awk -v value="gene_most_severe" -F "\t" -f headercheck.awk)
-			cat <(zcat ${external_annot}|head -n1|cut -f $vep_varcol,$vep_conscol,$vep_genecol) <(zcat ${external_annot}|cut -f $vep_varcol,$vep_conscol,$vep_genecol|sort -V -k 1,1)|bgzip > sorted_vep.gz
+			cat <(zcat ${external_annot}|head -n1|cut -f $vep_varcol,$vep_conscol,$vep_genecol) <(zcat ${external_annot}|cut -f $vep_varcol,$vep_conscol,$vep_genecol|sort -k 1b,1)|bgzip > sorted_vep.gz
 			#sort annotation
 			cat <(head -n 1 ${files[0]}) <(awk 'FNR>1' ${sep=" " files}) | bgzip > annotated_variants_1.gz
-			cat <(zcat annotated_variants_1.gz|head -n1)  <(zcat annotated_variants_1.gz|tail -n+2|sort -V -k 1,1 -T ./) |bgzip  > sorted_annotated.gz
+			cat <(zcat annotated_variants_1.gz|head -n1)  <(zcat annotated_variants_1.gz|tail -n+2|sort  -k 1b,1 -T ./) |bgzip  > sorted_annotated.gz
 			#join
-			join -t $'\t' -1 1 -2 1 -e "NA" --header -a 1 <(zcat sorted_annotated.gz) <(zcat sorted_vep.gz) |bgzip  > annotated_variants.gz
+			join -t $'\t' -1 1 -2 1 -e "NA" --header -a 1 <(zcat sorted_annotated.gz) <(zcat sorted_vep.gz)|sort -V -k1,1 -T ./ |bgzip  > annotated_variants.gz
 		fi
 
 		tabix -b 3 -e 3 -s 2 annotated_variants.gz

--- a/variant_annotation/wdl/scrape_annot_v4.wdl
+++ b/variant_annotation/wdl/scrape_annot_v4.wdl
@@ -58,6 +58,8 @@ task join_annot {
 			zcat annotated_variants.gz.tmp | body sort -V -k 1,1 -T ./ | bgzip  > sorted_annotated.gz
 			#join
 			join --nocheck-order -t $'\t' -1 1 -2 1 -e "NA" --header -a 1 <(zcat sorted_annotated.gz) <(zcat sorted_vep.gz) | bgzip > annotated_variants.gz
+        else
+            mv annotated_variants.gz.tmp annotated_variants.gz
 		fi
 
 		tabix -b 3 -e 3 -s 2 annotated_variants.gz

--- a/variant_annotation/wdl/scrape_annot_v4.wdl.r12.gnomad4.1.json
+++ b/variant_annotation/wdl/scrape_annot_v4.wdl.r12.gnomad4.1.json
@@ -1,0 +1,11 @@
+{
+    "scrape_annots.vcfs": "gs://r12-data/R12_imputed_genotypes_v3",
+    "scrape_annots.external_annot": "gs://finngen-imputation-panel/sisu4.2/fixed_PAR_X/sisu4.2_annot_annot_w_fixed_PAR_X.tsv.bgz",
+    "scrape_annots.add_rsids.ref_file": "gs://finngen_commons/dbsnp/dbsnp-b156-GRC38.13.left_aligned.vcf.gz",
+    "scrape_annots.small.wanted_columns": "#variant chr pos ref alt INFO AF AC_Het AC_Hom most_severe gene_most_severe rsid EXOME_enrichment_nfe GENOME_enrichment_nfe",
+    "scrape_annots.add_gnomad.gnomad_genomes":"gs://finngen-commons/gnomad/gnomad4/gnomad.genomes.v4.1.sites.merged.tsv.gz",
+    "scrape_annots.add_gnomad.gnomad_exomes":"gs://finngen-commons/gnomad/gnomad4/gnomad.exomes.v4.1.sites.merged.tsv.gz",
+    "scrape_annots.add_gnomad.genome_cols":["enrichment_nfe","AF_fin","AF_nfe","AC_fin","AC_nfe","AN_fin","AN_nfe"],
+    "scrape_annots.add_gnomad.exome_cols":["enrichment_nfe","AF_fin","AF_nfe","AC_fin","AC_nfe","AN_fin","AN_nfe"],
+    "scrape_annots.docker": "eu.gcr.io/finngen-refinery-dev/bioinformatics:0.8.2"
+}

--- a/variant_annotation/wdl/scrape_annot_v4.wdl.r12.json
+++ b/variant_annotation/wdl/scrape_annot_v4.wdl.r12.json
@@ -1,0 +1,11 @@
+{
+    "scrape_annots.vcfs": "gs://r12-data/annotation/vcf_list_r12",
+    "scrape_annots.external_annot": "gs://finngen-imputation-panel/sisu4.2/hail/sisu4.2_annot_annot.tsv.bgz",
+    "scrape_annots.add_rsids.ref_file": "gs://finngen_commons/dbsnp/dbsnp-b156-GRC38.13.left_aligned.split.vcf.gz",
+    "scrape_annots.small.wanted_columns": "#variant chr pos ref alt INFO AF AC_Het AC_Hom most_severe gene_most_severe rsid b37_coord EXOME_enrichment_nfsee EXOME_enrichment_nfe GENOME_enrichment_nfee GENOME_enrichment_nfe",
+    "scrape_annots.add_gnomad.gnomad_genomes":"gs://gnomad2/lifted_picard_b38/genomes/gnomad.2.1.1.genomes.b38.tsv.gz",
+    "scrape_annots.add_gnomad.gnomad_exomes":"gs://gnomad2/lifted_picard_b38/exomes/gnomad.2.1.1.exomes.b38.tsv.gz",
+    "scrape_annots.add_gnomad.genome_cols":["enrichment_nfe","enrichment_nfee","AF_fin","AF_nfe","AF_nfee"],
+    "scrape_annots.add_gnomad.exome_cols":["enrichment_nfe","enrichment_nfee","enrichment_nfse","enrichment_nfsee","AF_fin","AF_nfe","AF_nfee","AF_nfse","AF_nfsee"],
+    "scrape_annots.docker": "eu.gcr.io/finngen-refinery-dev/bioinformatics:0.8"
+}


### PR DESCRIPTION
- Added gnomad v4 vcf parsing workflow
- Modify scrape_annot to not require b37 coords in gnomad files
- Fix #45 